### PR TITLE
Fix swapped number of Input and Output channels

### DIFF
--- a/modules/juce_audio_devices/native/juce_emscripten_Audio.cpp
+++ b/modules/juce_audio_devices/native/juce_emscripten_Audio.cpp
@@ -359,12 +359,12 @@ public:
     BigInteger getActiveOutputChannels () const override
     {
         BigInteger b;
-        b.setRange (0, numIn, true);
+        b.setRange (0, numOut, true);
         return b;
     }
     BigInteger getActiveInputChannels () const override {
         BigInteger b;
-        b.setRange (0, numOut, true);
+        b.setRange (0, numIn, true);
         return b;
     }
 


### PR DESCRIPTION
I discovered this while working on an updated JUCE+emscripten port. It was a bit of a headache to find, so I wanted to note it here in case anyone else uses this port as a starting point.